### PR TITLE
Modified paho dependency configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation("org.immutables:value:$immutablesValueVersion")
     implementation("org.immutables:gson:$immutablesValueVersion")
 
-    implementation("org.eclipse.paho:org.eclipse.paho.client.mqttv3:$pahoVersion")
+    api("org.eclipse.paho:org.eclipse.paho.client.mqttv3:$pahoVersion")
     implementation("joda-time:joda-time:$jodaTimeVersion")
 
     implementation("software.amazon.awssdk:iot:$awsSdk2Version")


### PR DESCRIPTION
*Description of changes:*
Modify the `org.eclipse.paho.client.mqttv3` dependency configuration to use `MqttClient` without additional dependency configuration in other modules.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
